### PR TITLE
prevent close button `observeEvent` from being spuriously triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/R/data_filter_server.R
+++ b/R/data_filter_server.R
@@ -86,7 +86,7 @@ data_filter_server <- function(id, data) {
             inputId = "vars",
             selected = input$vars[input$vars != filter_var]
           )
-        })
+        }, ignoreInit = TRUE, once = TRUE)
       })
     })
 


### PR DESCRIPTION
Fixes #7.

`ignoreInit = TRUE` is needed because when a filter button is re-spawned after being clicked, it's input state is no longer NULL (because it has been clicked), and so without `ignoreInit` set, the observable is triggered and immediately removes the filter after adding.

`once = TRUE` is needed because without it, you get a sort of `observeEvent` memory leak -- add a `print` into the `observeEvent` with `once = FALSE` to see what I mean... every time the filter is added and removed, it adds a new instance of the observable to the chain. By contrast, with `once = TRUE`, the observable is destroyed as soon as it is triggered so they don't build up.

There is still sort of a memory leak: even with `once = TRUE` if you add and remove a filter via the `pickerInput` control, the observerable is not cleaned up, and so will build up instances. When the "close" button is finally clicked, all those instances you built up will all run and attempt to remove your filter multiple times. (This isn't a big deal for removing filters though because it's a no-op after the filter is actually removed... just good to know this is happening for other applications... this behavior would be quite insidious for a "toggle" operation, for example). 

This all begs the question -- is there a better way for creating dynamic / nested observables (as dv.filter does) so they can automatically be cleaned up when the UI changes instead of leaking and building up? Please let me know if you have any approaches for this! I haven't found one yet, but will update if I stumble on anything...